### PR TITLE
ci: Use sccache native GitHub Actions support

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -100,17 +100,15 @@ jobs:
         fi
 
     - name: Setup ccache
+      if: steps.ccache.outputs.variant == 'ccache'
       uses: hendrikmuhs/ccache-action@v1.2.10
       with:
           key: ${{ matrix.os }}-${{ matrix.python_version }}
-          variant: ${{ steps.ccache.outputs.variant }}
+          variant: ccache
 
-    - name: Set robotpy-build environment
-      shell: bash
-      run: |
-        echo "RPYBUILD_PARALLEL=1" >> $GITHUB_ENV
-        echo "RPYBUILD_STRIP_LIBPYTHON=1"  >> $GITHUB_ENV
-        echo "MACOSX_DEPLOYMENT_TARGET=11.7" >> $GITHUB_ENV
+    - name: Setup sccache
+      if: steps.ccache.outputs.variant == 'sccache'
+      uses: mozilla-actions/sccache-action@v0.0.3
 
     - name: Install deps
       shell: bash
@@ -126,6 +124,11 @@ jobs:
       shell: bash
       run: |
         ./rdev.sh ci run
+      env:
+        RPYBUILD_PARALLEL: "1"
+        RPYBUILD_STRIP_LIBPYTHON: "1"
+        MACOSX_DEPLOYMENT_TARGET: "11.7"
+        SCCACHE_GHA_ENABLED: "true"
 
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -191,13 +191,6 @@ jobs:
           key: ${{ matrix.os.container }}
           variant: ccache
 
-    - name: Set robotpy-build environment
-      shell: bash
-      run: |
-        echo "RPYBUILD_PARALLEL=1" >> $GITHUB_ENV
-        echo "RPYBUILD_STRIP_LIBPYTHON=1"  >> $GITHUB_ENV
-        echo "MACOSX_DEPLOYMENT_TARGET=11.7" >> $GITHUB_ENV
-
     - name: Install setuptools + wheel
       run: |
         /build/venv/bin/build-pip --disable-pip-version-check install -U "setuptools==63.4.3; python_version < '3.12'"
@@ -221,6 +214,9 @@ jobs:
       shell: bash
       run: |
         /build/venv/bin/cross-python -m devtools ci run --no-test
+      env:
+        RPYBUILD_PARALLEL: "1"
+        RPYBUILD_STRIP_LIBPYTHON: "1"
       
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
We're seeing 100% cache misses with the local disk cache. Let's see if letting sccache hit the Actions cache improves cache hits.

Ref: https://github.com/robotpy/build-actions/issues/15