### PR TITLE
Make swerve API more consistent

### DIFF
--- a/subprojects/robotpy-wpimath/gen/kinematics/SwerveDriveKinematics.yml
+++ b/subprojects/robotpy-wpimath/gen/kinematics/SwerveDriveKinematics.yml
@@ -19,34 +19,8 @@ classes:
       ResetHeadings:
         overloads:
           ModuleHeadings&&...:
-            param_override:
-              moduleHeadings:
-                ignore: true
-            cpp_code: |
-              []() {
-                if constexpr (NumModules == 2) {
-                  return [](SwerveDriveKinematics<NumModules> *self, Rotation2d r0, Rotation2d r1) {
-                    return self->ResetHeadings(r0, r1);
-                  };
-                } else if constexpr (NumModules == 3) {
-                  return [](SwerveDriveKinematics<NumModules> *self, Rotation2d r0, Rotation2d r1, Rotation2d r2) {
-                    return self->ResetHeadings(r0, r1, r2);
-                  };
-                } else if constexpr (NumModules == 4) {
-                  return [](SwerveDriveKinematics<NumModules> *self, Rotation2d r0, Rotation2d r1,
-                    Rotation2d r2, Rotation2d r3) {
-                    return self->ResetHeadings(r0, r1, r2, r3);
-                  };
-                } else if constexpr (NumModules == 6) {
-                  return [](SwerveDriveKinematics<NumModules> *self,
-                    Rotation2d r0, Rotation2d r1, Rotation2d r2,
-                    Rotation2d r3, Rotation2d r4, Rotation2d r5) {
-                    return self->ResetHeadings(r0, r1, r2, r3, r4, r5);
-                  };
-                }
-              }()
-          wpi::array<Rotation2d, NumModules>:
             ignore: true
+          wpi::array<Rotation2d, NumModules>:
 
       ToSwerveModuleStates:
         doc: |
@@ -77,65 +51,13 @@ classes:
       ToChassisSpeeds:
         overloads:
           ModuleStates&&... [const]:
-            param_override:
-              moduleStates:
-                ignore: true
-            cpp_code: |
-              []() {
-                if constexpr (NumModules == 2) {
-                  return [](SwerveDriveKinematics<NumModules> *self, SwerveModuleState p0, SwerveModuleState p1) {
-                    return self->ToChassisSpeeds(p0, p1);
-                  };
-                } else if constexpr (NumModules == 3) {
-                  return [](SwerveDriveKinematics<NumModules> *self, SwerveModuleState p0, SwerveModuleState p1, SwerveModuleState p2) {
-                    return self->ToChassisSpeeds(p0, p1, p2);
-                  };
-                } else if constexpr (NumModules == 4) {
-                  return [](SwerveDriveKinematics<NumModules> *self, SwerveModuleState p0, SwerveModuleState p1,
-                    SwerveModuleState p2, SwerveModuleState p3) {
-                    return self->ToChassisSpeeds(p0, p1, p2, p3);
-                  };
-                } else if constexpr (NumModules == 6) {
-                  return [](SwerveDriveKinematics<NumModules> *self,
-                    SwerveModuleState p0, SwerveModuleState p1, SwerveModuleState p2,
-                    SwerveModuleState p3, SwerveModuleState p4, SwerveModuleState p5) {
-                    return self->ToChassisSpeeds(p0, p1, p2, p3, p4, p5);
-                  };
-                }
-              }()
-          const wpi::array<SwerveModuleState, NumModules>& [const]:
             ignore: true
+          const wpi::array<SwerveModuleState, NumModules>& [const]:
       ToTwist2d:
         overloads:
           ModuleDeltas&&... [const]:
-            param_override:
-              moduleDeltas:
-                ignore: true
-            cpp_code: |
-              []() {
-                if constexpr (NumModules == 2) {
-                  return [](SwerveDriveKinematics<NumModules> *self, SwerveModulePosition p0, SwerveModulePosition p1) {
-                    return self->ToTwist2d(p0, p1);
-                  };
-                } else if constexpr (NumModules == 3) {
-                  return [](SwerveDriveKinematics<NumModules> *self, SwerveModulePosition p0, SwerveModulePosition p1, SwerveModulePosition p2) {
-                    return self->ToTwist2d(p0, p1, p2);
-                  };
-                } else if constexpr (NumModules == 4) {
-                  return [](SwerveDriveKinematics<NumModules> *self, SwerveModulePosition p0, SwerveModulePosition p1,
-                    SwerveModulePosition p2, SwerveModulePosition p3) {
-                    return self->ToTwist2d(p0, p1, p2, p3);
-                  };
-                } else if constexpr (NumModules == 6) {
-                  return [](SwerveDriveKinematics<NumModules> *self,
-                    SwerveModulePosition p0, SwerveModulePosition p1, SwerveModulePosition p2,
-                    SwerveModulePosition p3, SwerveModulePosition p4, SwerveModulePosition p5) {
-                    return self->ToTwist2d(p0, p1, p2, p3, p4, p5);
-                  };
-                }
-              }()
-          wpi::array<SwerveModulePosition, NumModules> [const]:
             ignore: true
+          wpi::array<SwerveModulePosition, NumModules> [const]:
           const SwerveDriveWheelPositions<NumModules>&, const SwerveDriveWheelPositions<NumModules>& [const]:
             ignore: true
       DesaturateWheelSpeeds:

--- a/subprojects/robotpy-wpimath/gen/kinematics/SwerveDriveOdometry.yml
+++ b/subprojects/robotpy-wpimath/gen/kinematics/SwerveDriveOdometry.yml
@@ -8,78 +8,8 @@ classes:
     methods:
       SwerveDriveOdometry:
       ResetPosition:
-        param_override:
-          gyroAngle:
-            ignore: true
-          modulePositions:
-            ignore: true
-          pose:
-            ignore: true
-        cpp_code: |
-          []() {
-            if constexpr (NumModules == 2) {
-              return [](SwerveDriveOdometry<NumModules> * self,
-                        const Rotation2d& gyroAngle, const Pose2d& pose,
-                        SwerveModulePosition s1, SwerveModulePosition s2) {
-                self->ResetPosition(gyroAngle, {s1, s2}, pose);
-              };
-            } else if constexpr (NumModules == 3) {
-              return [](SwerveDriveOdometry<NumModules> * self,
-                        const Rotation2d& gyroAngle, const Pose2d& pose,
-                        SwerveModulePosition s1, SwerveModulePosition s2, SwerveModulePosition s3) {
-                self->ResetPosition(gyroAngle, {s1, s2, s3}, pose);
-              };
-            } else if constexpr (NumModules == 4) {
-              return [](SwerveDriveOdometry<NumModules> * self,
-                        const Rotation2d& gyroAngle, const Pose2d& pose,
-                        SwerveModulePosition s1, SwerveModulePosition s2,
-                        SwerveModulePosition s3, SwerveModulePosition s4) {
-                self->ResetPosition(gyroAngle, {s1, s2, s3, s4}, pose);
-              };
-            } else if constexpr (NumModules == 6) {
-              return [](SwerveDriveOdometry<NumModules> * self,
-                        const Rotation2d& gyroAngle, const Pose2d& pose,
-                        SwerveModulePosition s1, SwerveModulePosition s2,
-                        SwerveModulePosition s3, SwerveModulePosition s4,
-                        SwerveModulePosition s5, SwerveModulePosition s6) {
-                self->ResetPosition(gyroAngle, {s1, s2, s3, s4, s5, s6}, pose);
-              };
-            }
-          }()
       GetPose:
       Update:
-        param_override:
-          gyroAngle:
-            ignore: true
-          modulePositions:
-            ignore: true
-        cpp_code: |
-          []() {
-            if constexpr (NumModules == 2) {
-              return [](SwerveDriveOdometry<NumModules> * self, const Rotation2d& gyroAngle,
-                        SwerveModulePosition s1, SwerveModulePosition s2) {
-                return self->Update(gyroAngle, {s1, s2});
-              };
-            } else if constexpr (NumModules == 3) {
-              return [](SwerveDriveOdometry<NumModules> * self, const Rotation2d& gyroAngle,
-                        SwerveModulePosition s1, SwerveModulePosition s2, SwerveModulePosition s3) {
-                return self->Update(gyroAngle, {s1, s2, s3});
-              };
-            } else if constexpr (NumModules == 4) {
-              return [](SwerveDriveOdometry<NumModules> * self, const Rotation2d& gyroAngle,
-                        SwerveModulePosition s1, SwerveModulePosition s2,
-                        SwerveModulePosition s3, SwerveModulePosition s4) {
-                return self->Update(gyroAngle, {s1, s2, s3, s4});
-              };
-            } else if constexpr (NumModules == 6) {
-              return [](SwerveDriveOdometry<NumModules> * self, const Rotation2d& gyroAngle,
-                        SwerveModulePosition s1, SwerveModulePosition s2,
-                        SwerveModulePosition s3, SwerveModulePosition s4,
-                        SwerveModulePosition s5, SwerveModulePosition s6) {
-                return self->Update(gyroAngle, {s1, s2, s3, s4, s5, s6});
-              };
-            }
-          }()
 templates:
   SwerveDrive2Odometry:
     qualname: frc::SwerveDriveOdometry

--- a/subprojects/robotpy-wpimath/tests/test_kinematics.py
+++ b/subprojects/robotpy-wpimath/tests/test_kinematics.py
@@ -40,7 +40,7 @@ def test_swerve4_normalize():
     s3 = SwerveModuleState(4)
     s4 = SwerveModuleState(7)
 
-    states = SwerveDrive4Kinematics.desaturateWheelSpeeds([s1, s2, s3, s4], 5.5)
+    states = SwerveDrive4Kinematics.desaturateWheelSpeeds((s1, s2, s3, s4), 5.5)
 
     kFactor = 5.5 / 7.0
 
@@ -53,19 +53,21 @@ def test_swerve4_normalize():
 def test_swerve4_odometry(s4: SwerveDrive4Kinematics):
     zero = SwerveModulePosition()
     odometry = SwerveDrive4Odometry(s4, Rotation2d(0), (zero, zero, zero, zero))
-    odometry.resetPosition(Rotation2d(0), Pose2d(), zero, zero, zero, zero)
+    odometry.resetPosition(Rotation2d(0), (zero, zero, zero, zero), Pose2d())
 
     position = SwerveModulePosition(0.5)
 
     odometry.update(
         Rotation2d(0),
-        zero,
-        zero,
-        zero,
-        zero,
+        (
+            zero,
+            zero,
+            zero,
+            zero,
+        ),
     )
 
-    pose = odometry.update(Rotation2d(0), position, position, position, position)
+    pose = odometry.update(Rotation2d(0), (position, position, position, position))
 
     print(pose)
     assert pose.x == pytest.approx(0.5)


### PR DESCRIPTION
- Require tuples in most places

I'm excluding the constructor of `SwerveDriveKinematics` because it feels more natural as-is.