### PR TITLE
wpilib: Expose SysIdRoutineLog angular methods

### DIFF
--- a/subprojects/robotpy-wpilib/gen/SysIdRoutineLog.yml
+++ b/subprojects/robotpy-wpilib/gen/SysIdRoutineLog.yml
@@ -22,12 +22,15 @@ classes:
         overloads:
           units::meter_t:
           units::turn_t:
+            rename: angularPosition
       velocity:
         overloads:
           units::meters_per_second_t:
           units::turns_per_second_t:
+            rename: angularVelocity
       acceleration:
         overloads:
           units::meters_per_second_squared_t:
           units::turns_per_second_squared_t:
+            rename: angularAcceleration
       current:


### PR DESCRIPTION
These overloads are currently unusable as the first overload will match.

Matches the Java naming: https://github.com/wpilibsuite/allwpilib/blob/a70e83ae2e6d6fe80f8d8e2dfe26fbec548a833e/wpilibj/src/main/java/edu/wpi/first/wpilibj/sysid/SysIdRoutineLog.java#L137