### PR TITLE
Implement wpilib.sysid.State.__str__ for Java parity

### DIFF
--- a/subprojects/robotpy-wpilib/gen/SysIdRoutineLog.yml
+++ b/subprojects/robotpy-wpilib/gen/SysIdRoutineLog.yml
@@ -4,9 +4,7 @@ enums:
   State:
     subpackage: sysid
     inline_code: |
-      .def("__str__", [](State self) {
-        return SysIdRoutineLog::StateEnumToString(self);
-      })
+      .def("__str__", &SysIdRoutineLog::StateEnumToString)
 
 classes:
   SysIdRoutineLog:

--- a/subprojects/robotpy-wpilib/gen/SysIdRoutineLog.yml
+++ b/subprojects/robotpy-wpilib/gen/SysIdRoutineLog.yml
@@ -3,6 +3,11 @@
 enums:
   State:
     subpackage: sysid
+    inline_code: |
+      .def("__str__", [](State self) {
+        return SysIdRoutineLog::StateEnumToString(self);
+      })
+
 classes:
   SysIdRoutineLog:
     subpackage: sysid


### PR DESCRIPTION
The Java version overrides `toString`: https://github.com/wpilibsuite/allwpilib/blob/68736d802d0764d8116dfc82fe42819b0cdbbbc3/wpilibj/src/main/java/edu/wpi/first/wpilibj/sysid/SysIdRoutineLog.java#L68-L70

Addresses https://github.com/robotpy/robotpy-commands-v2/pull/43#discussion_r1448885756