### PR TITLE
Allow accessing AddressableLED.LEDData fields

### DIFF
--- a/subprojects/robotpy-hal/gen/AddressableLEDTypes.yml
+++ b/subprojects/robotpy-hal/gen/AddressableLEDTypes.yml
@@ -11,3 +11,4 @@ classes:
       g:
       r:
       padding:
+        ignore: true

--- a/subprojects/robotpy-wpilib/gen/AddressableLED.yml
+++ b/subprojects/robotpy-wpilib/gen/AddressableLED.yml
@@ -2,7 +2,6 @@
 
 classes:
   AddressableLED:
-    shared_ptr: true
     methods:
       AddressableLED:
       SetLength:
@@ -16,10 +15,9 @@ classes:
       Start:
       Stop:
   AddressableLED::LEDData:
-    shared_ptr: true
-    ignored_bases:
-    - HAL_AddressableLEDData
     force_no_trampoline: true
+    base_qualnames:
+      HAL_AddressableLEDData: ::HAL_AddressableLEDData
     methods:
       LEDData:
         overloads:


### PR DESCRIPTION
[`wpilib.AddressableLED.LEDData.setRGB`] is documented as:

> A helper method to set all values of the LED.

But how do you set the individual values of the LED? In C++ you'd be able to set the `r`, `g`, and `b` members. However our bindings currently don't allow that, because we hide the fact that `LEDData` subclasses the `hal.AddressableLEDData` struct.

This makes those member variables visible via the base `hal.AddressableLEDData`.

[`wpilib.AddressableLED.LEDData.setRGB`]: https://robotpy.readthedocs.io/projects/robotpy/en/stable/wpilib/AddressableLED.html#wpilib.AddressableLED.LEDData.setRGB