### PR TITLE
pyntcore: Add struct topics constructors

### DIFF
--- a/subprojects/pyntcore/gen/StructArrayTopic.yml
+++ b/subprojects/pyntcore/gen/StructArrayTopic.yml
@@ -114,7 +114,14 @@ classes:
           NT_Topic, I...:
             ignore: true
           Topic, I...:
-            ignore: true
+            param_override:
+              info:
+                name: type
+            cpp_code: |
+              [](Topic topic, const py::type &t) {
+                WPyStructInfo info(t);
+                return nt::StructArrayTopic<T, I>(topic, info);
+              }
       Subscribe:
         overloads:
           U&&, const PubSubOptions&:

--- a/subprojects/pyntcore/gen/StructTopic.yml
+++ b/subprojects/pyntcore/gen/StructTopic.yml
@@ -104,7 +104,14 @@ classes:
           NT_Topic, I...:
             ignore: true
           Topic, I...:
-            ignore: true
+            param_override:
+              info:
+                name: type
+            cpp_code: |
+              [](Topic topic, const py::type &t) {
+                WPyStructInfo info(t);
+                return nt::StructTopic<T, I>(topic, info);
+              }
       Subscribe:
       Publish:
       PublishEx:


### PR DESCRIPTION
I'd like to add support for `@magicbot.feedback` to publish structs (see https://github.com/robotpy/robotpy-wpilib-utilities/pull/208 for utilising type hints along those lines). Without these constructors adding such support will be annoying.