### PR TITLE
Fix dist workflow by upgrading MSVC toolset

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Setup msvc version
       uses: ilammy/msvc-dev-cmd@v1
       with:
-        toolset: "14.39"
+        toolset: "14.40"
 
     #
     # Setup build caching


### PR DESCRIPTION
Actions no longer provides 14.39, so we need to upgrade to 14.40.