### PR TITLE
Make AprilTagDetection.Point unpackable

### DIFF
--- a/subprojects/robotpy-apriltag/gen/AprilTagDetection.yml
+++ b/subprojects/robotpy-apriltag/gen/AprilTagDetection.yml
@@ -29,6 +29,17 @@ classes:
         AprilTagDetection::Point pt{x, y};
         return std::make_unique<AprilTagDetection::Point>(std::move(pt));
       }), py::arg("x"), py::arg("y"))
+      .def("__len__", [](const AprilTagDetection::Point &self) { return 2; })
+      .def("__getitem__", [](const AprilTagDetection::Point &self, int index) {
+        switch (index) {
+          case 0:
+            return self.x;
+          case 1:
+            return self.y;
+          default:
+            throw std::out_of_range("AprilTagDetection.Point index out of range");
+        }
+      })
       .def("__repr__", [](const AprilTagDetection::Point &self) {
-        return py::str("Point(x={}, y={})").format(self.x, self.y);
+        return py::str("AprilTagDetection.Point(x={}, y={})").format(self.x, self.y);
       })

--- a/subprojects/robotpy-apriltag/tests/test_detection.py
+++ b/subprojects/robotpy-apriltag/tests/test_detection.py
@@ -7,6 +7,15 @@ import pathlib
 import pytest
 
 
+def test_point():
+    point = robotpy_apriltag.AprilTagDetection.Point()
+
+    x, y = point
+
+    assert x == 0
+    assert y == 0
+
+
 def _load_grayscale_image(fname):
     full_path = pathlib.Path(__file__).parent / fname
     img = cv2.imread(str(full_path))


### PR DESCRIPTION
`AprilTagDetection.Point` is plain old data. Make it unpackable like Translation2d, and behave more similarly to a namedtuple.