### PR TITLE
ci: Fix cache cleanup for PRs from forks

### DIFF
--- a/.github/workflows/cleanup-cache.yml
+++ b/.github/workflows/cleanup-cache.yml
@@ -2,7 +2,7 @@
 name: cleanup branch caches
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
Closing and merging PRs from forks is currently causing this workflow to fail with several messages:

```
Error: Resource not accessible by integration
```

since workflows triggered on `pull_request` don't have write access to the target repo.