### PR TITLE
Fix AprilTagDetector.detect() doc string: height, width

### DIFF
--- a/subprojects/robotpy-apriltag/gen/AprilTagDetector.yml
+++ b/subprojects/robotpy-apriltag/gen/AprilTagDetector.yml
@@ -56,7 +56,7 @@ classes:
         return l;
       }, py::arg("image"),
         R"doc(
-          Detect tags from an 8-bit grayscale image with shape (width, height)
+          Detect tags from an 8-bit grayscale image with shape (height, width)
 
           :return: list of results
         )doc"


### PR DESCRIPTION
I think the confusion is that the underlying Apriltag library does say "width, height":

```
  Results Detect(int width, int height, int stride, uint8_t* buf);
```

But the python ndarray shape is actually (height, width), isn't it?