### PR TITLE
wpimath: Add numpy dependency

### DIFF
--- a/subprojects/robotpy-wpimath/pyproject.toml
+++ b/subprojects/robotpy-wpimath/pyproject.toml
@@ -6,6 +6,7 @@ license = "BSD-3-Clause"
 name = "robotpy-wpimath"
 url = "https://github.com/robotpy/robotpy-wpimath"
 install_requires = [
+    "numpy",
     "robotpy-wpiutil==THIS_VERSION",
 ]
 


### PR DESCRIPTION
wpilibsuite/allwpilib#7430 added, among others, a `Rotation2d` constructor overload that takes an `Eigen::Matrix2d`. This now means calling the `Rotation2d` constructor requires numpy to be installed for the pybind11 Eigen caster to work.

This breakage was noticed downstream in https://github.com/robotpy/robotpy-commands-v2/pull/79#issuecomment-2561336675