### PR TITLE
Rename geometry from matrix constructor overloads

### DIFF
--- a/rdev.toml
+++ b/rdev.toml
@@ -13,7 +13,7 @@ exclude_artifacts = [
     "opencv-cpp"
 ]
 
-robotpy_build_req = "<2025.0.0b1,~=2025.0.0a6"
+robotpy_build_req = "<2025.0.0b1,~=2025.0.0a8"
 
 #
 # Subproject configuration

--- a/subprojects/pyntcore/pyproject.toml
+++ b/subprojects/pyntcore/pyproject.toml
@@ -12,7 +12,7 @@ install_requires = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-wpiutil~=2025.0.0b3",
     "robotpy-wpinet~=2025.0.0b3",
 ]

--- a/subprojects/robotpy-apriltag/pyproject.toml
+++ b/subprojects/robotpy-apriltag/pyproject.toml
@@ -12,7 +12,7 @@ install_requires = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-wpiutil~=2025.0.0b3",
     "robotpy-wpimath~=2025.0.0b3",
 ]

--- a/subprojects/robotpy-cscore/pyproject.toml
+++ b/subprojects/robotpy-cscore/pyproject.toml
@@ -13,7 +13,7 @@ install_requires = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-wpiutil~=2025.0.0b3",
     "robotpy-wpinet~=2025.0.0b3",
     "pyntcore~=2025.0.0b3",

--- a/subprojects/robotpy-hal/pyproject.toml
+++ b/subprojects/robotpy-hal/pyproject.toml
@@ -11,7 +11,7 @@ install_requires = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-wpiutil~=2025.0.0b3",
 ]
 

--- a/subprojects/robotpy-halsim-ds-socket/pyproject.toml
+++ b/subprojects/robotpy-halsim-ds-socket/pyproject.toml
@@ -15,7 +15,7 @@ robotpysimext = ["ds-socket = halsim_ds_socket"]
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-hal~=2025.0.0b3",
     "robotpy-wpinet~=2025.0.0b3",
 ]

--- a/subprojects/robotpy-halsim-gui/pyproject.toml
+++ b/subprojects/robotpy-halsim-gui/pyproject.toml
@@ -14,7 +14,7 @@ install_requires = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-wpiutil~=2025.0.0b3",
     "robotpy-wpimath~=2025.0.0b3",
     "robotpy-hal~=2025.0.0b3",

--- a/subprojects/robotpy-halsim-ws/pyproject.toml
+++ b/subprojects/robotpy-halsim-ws/pyproject.toml
@@ -19,7 +19,7 @@ robotpysimext = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-hal~=2025.0.0b3",
     "robotpy-wpinet~=2025.0.0b3",
 ]

--- a/subprojects/robotpy-romi/pyproject.toml
+++ b/subprojects/robotpy-romi/pyproject.toml
@@ -11,7 +11,7 @@ install_requires = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "wpilib~=2025.0.0b3"
 ]
 

--- a/subprojects/robotpy-wpilib/pyproject.toml
+++ b/subprojects/robotpy-wpilib/pyproject.toml
@@ -18,7 +18,7 @@ robotpy = ["run = wpilib._impl.start:Main"]
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-wpiutil~=2025.0.0b3",
     "robotpy-wpimath~=2025.0.0b3",
     "robotpy-hal~=2025.0.0b3",

--- a/subprojects/robotpy-wpimath/gen/geometry/Pose2d.yml
+++ b/subprojects/robotpy-wpimath/gen/geometry/Pose2d.yml
@@ -21,6 +21,9 @@ classes:
           '':
           Translation2d, Rotation2d:
           units::meter_t, units::meter_t, Rotation2d:
+          const Eigen::Matrix3d&:
+            rename: fromMatrix
+            keepalive: []
       Translation:
       Rotation:
       RotateBy:
@@ -28,6 +31,7 @@ classes:
       RelativeTo:
       Exp:
       Log:
+      ToMatrix:
       Nearest:
         overloads:
           std::span<const Pose2d> [const]:

--- a/subprojects/robotpy-wpimath/gen/geometry/Pose3d.yml
+++ b/subprojects/robotpy-wpimath/gen/geometry/Pose3d.yml
@@ -23,6 +23,10 @@ classes:
           Translation3d, Rotation3d:
           units::meter_t, units::meter_t, units::meter_t, Rotation3d:
           const Pose2d&:
+            keepalive: []
+          const Eigen::Matrix4d&:
+            rename: fromMatrix
+            keepalive: []
       operator+:
       operator-:
       operator==:
@@ -39,6 +43,7 @@ classes:
       RelativeTo:
       Exp:
       Log:
+      ToMatrix:
       ToPose2d:
 
 inline_code: |

--- a/subprojects/robotpy-wpimath/gen/geometry/Rotation2d.yml
+++ b/subprojects/robotpy-wpimath/gen/geometry/Rotation2d.yml
@@ -25,7 +25,11 @@ classes:
             template_impls:
               - ['units::radian_t']
           double, double:
+          const Eigen::Matrix2d&:
+            rename: fromMatrix
+            keepalive: []
       RotateBy:
+      ToMatrix:
       Radians:
       Degrees:
       Cos:

--- a/subprojects/robotpy-wpimath/gen/geometry/Rotation3d.yml
+++ b/subprojects/robotpy-wpimath/gen/geometry/Rotation3d.yml
@@ -16,12 +16,18 @@ classes:
         overloads:
           '':
           const Quaternion&:
+            keepalive: []
           units::radian_t, units::radian_t, units::radian_t:
           const Eigen::Vector3d&, units::radian_t:
+            keepalive: []
           const Eigen::Vector3d&:
+            keepalive: []
           const Eigen::Matrix3d&:
+            keepalive: []
           const Eigen::Vector3d&, const Eigen::Vector3d&:
+            keepalive: []
           const Rotation2d&:
+            keepalive: []
       operator+:
       operator-:
         overloads:
@@ -38,6 +44,7 @@ classes:
       Z:
       Axis:
       Angle:
+      ToMatrix:
       ToRotation2d:
 
 inline_code: |

--- a/subprojects/robotpy-wpimath/gen/geometry/Transform2d.yml
+++ b/subprojects/robotpy-wpimath/gen/geometry/Transform2d.yml
@@ -16,13 +16,18 @@ classes:
       Transform2d:
         overloads:
           const Pose2d&, const Pose2d&:
+            keepalive: []
           Translation2d, Rotation2d:
           units::meter_t, units::meter_t, Rotation2d:
+          const Eigen::Matrix3d&:
+            rename: fromMatrix
+            keepalive: []
           '':
       Translation:
-      Rotation:
       X:
       Y:
+      ToMatrix:
+      Rotation:
       Inverse:
       operator*:
       operator/:

--- a/subprojects/robotpy-wpimath/gen/geometry/Transform3d.yml
+++ b/subprojects/robotpy-wpimath/gen/geometry/Transform3d.yml
@@ -15,14 +15,20 @@ classes:
       Transform3d:
         overloads:
           const Pose3d&, const Pose3d&:
+            keepalive: []
           Translation3d, Rotation3d:
           units::meter_t, units::meter_t, units::meter_t, Rotation3d:
+          const Eigen::Matrix4d&:
+            rename: fromMatrix
+            keepalive: []
           '':
           const frc::Transform2d&:
+            keepalive: []
       Translation:
       X:
       Y:
       Z:
+      ToMatrix:
       Rotation:
       Inverse:
       operator*:

--- a/subprojects/robotpy-wpimath/pyproject.toml
+++ b/subprojects/robotpy-wpimath/pyproject.toml
@@ -11,7 +11,7 @@ install_requires = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-wpiutil~=2025.0.0b3",
     # "numpy", # broken in raspbian CI
 ]

--- a/subprojects/robotpy-wpimath/tests/geometry/test_rotation2d.py
+++ b/subprojects/robotpy-wpimath/tests/geometry/test_rotation2d.py
@@ -1,0 +1,80 @@
+import importlib.util
+import math
+
+import pytest
+
+from wpimath.geometry import Rotation2d
+
+
+@pytest.mark.parametrize(
+    "radians,degrees",
+    [
+        (math.pi / 3, 60.0),
+        (math.pi / 4, 45.0),
+    ],
+)
+def test_radians_to_degrees(radians: float, degrees: float):
+    rot = Rotation2d(radians)
+    assert math.isclose(degrees, rot.degrees())
+
+
+@pytest.mark.parametrize(
+    "degrees,radians",
+    [
+        (45.0, math.pi / 4),
+        (30.0, math.pi / 6),
+    ],
+)
+def test_degrees_to_radians(degrees: float, radians: float):
+    rot = Rotation2d.fromDegrees(degrees)
+    assert math.isclose(radians, rot.radians())
+
+
+def test_rotate_by_from_zero() -> None:
+    zero = Rotation2d()
+    rotated = zero + Rotation2d.fromDegrees(90)
+
+    assert math.isclose(math.pi / 2, rotated.radians())
+    assert math.isclose(90.0, rotated.degrees())
+
+
+def test_rotate_by_non_zero() -> None:
+    rot = Rotation2d.fromDegrees(90.0)
+    rot += Rotation2d.fromDegrees(30.0)
+
+    assert math.isclose(120.0, rot.degrees())
+
+
+def test_minus() -> None:
+    rot1 = Rotation2d.fromDegrees(70)
+    rot2 = Rotation2d.fromDegrees(30)
+
+    assert math.isclose(40.0, (rot1 - rot2).degrees())
+
+
+def test_unary_minus() -> None:
+    rot = Rotation2d.fromDegrees(20)
+    assert math.isclose(-20.0, (-rot).degrees())
+
+
+def test_equality() -> None:
+    rot1 = Rotation2d.fromDegrees(43.0)
+    rot2 = Rotation2d.fromDegrees(43.0)
+    assert rot1 == rot2
+
+    rot1 = Rotation2d.fromDegrees(-180.0)
+    rot2 = Rotation2d.fromDegrees(180.0)
+    assert rot1 == rot2
+
+
+def test_inequality() -> None:
+    rot1 = Rotation2d.fromDegrees(43.0)
+    rot2 = Rotation2d.fromDegrees(43.5)
+    assert rot1 != rot2
+
+
+@pytest.mark.skipif(importlib.util.find_spec("numpy") is None)
+def test_to_matrix() -> None:
+    before = Rotation2d.fromDegrees(20.0)
+    after = Rotation2d.fromMatrix(before.toMatrix())
+    assert before == after

--- a/subprojects/robotpy-wpimath/tests/geometry/test_rotation2d.py
+++ b/subprojects/robotpy-wpimath/tests/geometry/test_rotation2d.py
@@ -73,7 +73,9 @@ def test_inequality() -> None:
     assert rot1 != rot2
 
 
-@pytest.mark.skipif(importlib.util.find_spec("numpy") is None)
+@pytest.mark.skipif(
+    importlib.util.find_spec("numpy") is None, reason="numpy is not available"
+)
 def test_to_matrix() -> None:
     before = Rotation2d.fromDegrees(20.0)
     after = Rotation2d.fromMatrix(before.toMatrix())

--- a/subprojects/robotpy-wpinet/pyproject.toml
+++ b/subprojects/robotpy-wpinet/pyproject.toml
@@ -41,6 +41,6 @@ install_requires = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "robotpy-wpiutil~=2025.0.0b3",
 ]

--- a/subprojects/robotpy-wpiutil/pyproject.toml
+++ b/subprojects/robotpy-wpiutil/pyproject.toml
@@ -9,7 +9,7 @@ install_requires = []
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
 ]
 
 [tool.robotpy-build]

--- a/subprojects/robotpy-xrp/pyproject.toml
+++ b/subprojects/robotpy-xrp/pyproject.toml
@@ -16,7 +16,7 @@ robotpysimext = [
 
 [build-system]
 requires = [
-    "robotpy-build<2025.0.0b1,~=2025.0.0a6",
+    "robotpy-build<2025.0.0b1,~=2025.0.0a8",
     "wpilib~=2025.0.0b3"
 ]
 


### PR DESCRIPTION
See #119 for context.

Declaring numpy as a dependency is a no-go, but also we want to avoid importing numpy where possible. When using OpenBLAS (as we do for the roboRIO) importing numpy will initialise OpenBLAS, and OpenBLAS will allocate memory regions, which adds memory pressure.

Also, disable the keepalive inference for the various geometry constructors. These references aren't held after the constructor returns.

Depends on:
- https://github.com/robotpy/robotpy-build/pull/241
- https://github.com/robotpy/robotpy-build/pull/242