### PR TITLE
ci: Use Artifactory for Windows compiler caches

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -14,6 +14,10 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  SCCACHE_WEBDAV_ENDPOINT: "https://frcmaven.wpi.edu/artifactory/wpilib-generic-cache-cmake-local"
+  SCCACHE_WEBDAV_KEY_PREFIX: "sccache-robotpy"
+
 jobs:
   # This job limits concurrency on the default branch
   # - we want it to run so it can populate ccache, but we typically
@@ -128,6 +132,8 @@ jobs:
       env:
         RPYBUILD_STRIP_LIBPYTHON: "1"
         RPYBUILD_CC_LAUNCHER: ${{ steps.ccache.outputs.variant }}
+        SCCACHE_WEBDAV_USERNAME: ${{ secrets.WPI_ARTIFACTORY_USERNAME }}
+        SCCACHE_WEBDAV_PASSWORD: ${{ secrets.WPI_ARTIFACTORY_TOKEN }}
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -88,23 +88,28 @@ jobs:
     # Setup build caching
     #
 
-    - name: Set ccache size
+    - name: Set ccache params
       shell: bash
       id: ccache
       run: |
         if [[ "${{ runner.os }}" == "Windows" ]]; then
-          echo "MAX_SIZE=1200M" >> $GITHUB_OUTPUT
+          echo "VARIANT=sccache" >> $GITHUB_OUTPUT
         else
+          echo "VARIANT=ccache" >> $GITHUB_OUTPUT
           echo "MAX_SIZE=500M" >> $GITHUB_OUTPUT
         fi
 
     - name: Setup ccache
-      # uses: hendrikmuhs/ccache-action@v1.2.10
-      uses: robotpy/ccache-action@fork
+      if: steps.ccache.outputs.variant == 'ccache'
+      uses: hendrikmuhs/ccache-action@v1.2
       with:
           key: ${{ matrix.os }}-${{ matrix.python_version }}
           variant: ccache
           max-size: ${{ steps.ccache.outputs.max_size }}
+
+    - name: Setup sccache
+      if: steps.ccache.outputs.variant == 'sccache'
+      uses: mozilla-actions/sccache-action@v0.0.7
 
     - name: Install deps
       shell: bash
@@ -122,7 +127,7 @@ jobs:
         ./rdev.sh ci run
       env:
         RPYBUILD_STRIP_LIBPYTHON: "1"
-        RPYBUILD_CC_LAUNCHER: ccache
+        RPYBUILD_CC_LAUNCHER: ${{ steps.ccache.outputs.variant }}
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This switches our Windows builds to use sccache again, and use WPILib's Artifactory as its storage instead of the unperformant GitHub Actions cache.

We're only switching the Windows builds now to avoid saturating our Linux and macOS runners with long running jobs right now (when we're also busy cutting releases). Switching all our builds may happen in a follow-up PR, where we'll populate the caches in a controlled manner.