### PR TITLE
add dependency on msvc-runtime on windows

### DIFF
--- a/subprojects/robotpy-wpiutil/pyproject.toml
+++ b/subprojects/robotpy-wpiutil/pyproject.toml
@@ -5,7 +5,9 @@ author = "RobotPy Development Team"
 author_email = "robotpy@googlegroups.com"
 url = "https://github.com/robotpy/robotpy-wpiutil"
 license = "BSD-3-Clause"
-install_requires = []
+install_requires = [
+    "msvc-runtime>=14.42.34433; platform_system == 'Windows'"
+]
 
 [build-system]
 requires = [


### PR DESCRIPTION
All the native stuff eventually depends on wpiutil.

Robotpy-build should probably get a form of THIS_VERSION that finds the latest version of msvc-runtime on pypi and injects it to keep it up to date.