### PR TITLE
Disallow pydantic 1.10.20

### DIFF
--- a/rdev_requirements.txt
+++ b/rdev_requirements.txt
@@ -1,7 +1,7 @@
 black
 click
 packaging
-pydantic<2
+pydantic<2,!=1.10.20
 pytest
 requests
 setuptools


### PR DESCRIPTION
Pydantic 1.10.20 breaks on Python 3.12.0 to 3.12.4.

Whilst we really should update robotpy-build to Pydantic 2 (https://github.com/robotpy/robotpy-build/issues/212) and/or update Python 3.12 in our containers (https://github.com/wpilibsuite/docker-images/pull/39), add a constraint here now to unblock builds on this repo.