### PR TITLE
pyntcore: Add repr for entries and topics

### DIFF
--- a/subprojects/pyntcore/gen/NetworkTableEntry.yml
+++ b/subprojects/pyntcore/gen/NetworkTableEntry.yml
@@ -102,5 +102,5 @@ classes:
       operator!=:
     inline_code: |
       .def("__repr__", [](const NetworkTableEntry &self) {
-        return py::str("<NetworkTableEntry {}>").format(self.GetName());
+        return py::str("<NetworkTableEntry {!r}>").format(self.GetName());
       })

--- a/subprojects/pyntcore/gen/NetworkTableEntry.yml
+++ b/subprojects/pyntcore/gen/NetworkTableEntry.yml
@@ -101,6 +101,6 @@ classes:
       operator==:
       operator!=:
     inline_code: |
-      .def("__repr__", [](const NetworkTableEntry &self) {
+      .def("__repr__", [](NetworkTableEntry self) {
         return py::str("<NetworkTableEntry {!r}>").format(self.GetName());
       })

--- a/subprojects/pyntcore/gen/NetworkTableEntry.yml
+++ b/subprojects/pyntcore/gen/NetworkTableEntry.yml
@@ -100,3 +100,7 @@ classes:
       GetTopic:
       operator==:
       operator!=:
+    inline_code: |
+      .def("__repr__", [](const NetworkTableEntry &self) {
+        return py::str("<NetworkTableEntry {}>").format(self.GetName());
+      })

--- a/subprojects/pyntcore/gen/Topic.yml
+++ b/subprojects/pyntcore/gen/Topic.yml
@@ -48,7 +48,7 @@ classes:
       .def("__repr__", [](py::handle self) {
         py::object type_name = self.get_type().attr("__qualname__");
         std::string name = self.cast<const Topic&>().GetName();
-        return py::str("<{} {}>").format(type_name, name);
+        return py::str("<{} {!r}>").format(type_name, name);
       })
   Subscriber:
     attributes:
@@ -69,7 +69,7 @@ classes:
       .def("__repr__", [](py::handle self) {
         py::object type_name = self.get_type().attr("__qualname__");
         auto topic = self.cast<const Subscriber&>().GetTopic();
-        return py::str("<{} {}>").format(type_name, topic.GetName());
+        return py::str("<{} {!r}>").format(type_name, topic.GetName());
       })
   Publisher:
     attributes:
@@ -88,5 +88,5 @@ classes:
       .def("__repr__", [](py::handle self) {
         py::object type_name = self.get_type().attr("__qualname__");
         auto topic = self.cast<const Publisher&>().GetTopic();
-        return py::str("<{} {}>").format(type_name, topic.GetName());
+        return py::str("<{} {!r}>").format(type_name, topic.GetName());
       })

--- a/subprojects/pyntcore/gen/Topic.yml
+++ b/subprojects/pyntcore/gen/Topic.yml
@@ -44,6 +44,12 @@ classes:
           std::string_view, const PubSubOptions&:
       operator==:
       operator!=:
+    inline_code: |
+      .def("__repr__", [](py::handle self) {
+        py::object type_name = self.get_type().attr("__qualname__");
+        std::string name = self.cast<const Topic&>().GetName();
+        return py::str("<{} {}>").format(type_name, name);
+      })
   Subscriber:
     attributes:
       m_subHandle:
@@ -59,6 +65,12 @@ classes:
             ignore: true
           NT_Subscriber:
             ignore: true
+    inline_code: |
+      .def("__repr__", [](py::handle self) {
+        py::object type_name = self.get_type().attr("__qualname__");
+        auto topic = self.cast<const Subscriber&>().GetTopic();
+        return py::str("<{} {}>").format(type_name, topic.GetName());
+      })
   Publisher:
     attributes:
       m_pubHandle:
@@ -72,3 +84,9 @@ classes:
             ignore: true
           NT_Publisher:
             ignore: true
+    inline_code: |
+      .def("__repr__", [](py::handle self) {
+        py::object type_name = self.get_type().attr("__qualname__");
+        auto topic = self.cast<const Publisher&>().GetTopic();
+        return py::str("<{} {}>").format(type_name, topic.GetName());
+      })

--- a/subprojects/pyntcore/gen/Topic.yml
+++ b/subprojects/pyntcore/gen/Topic.yml
@@ -47,7 +47,7 @@ classes:
     inline_code: |
       .def("__repr__", [](py::handle self) {
         py::object type_name = self.get_type().attr("__qualname__");
-        std::string name = self.cast<const Topic&>().GetName();
+        std::string name = self.cast<Topic>().GetName();
         return py::str("<{} {!r}>").format(type_name, name);
       })
   Subscriber:

--- a/subprojects/pyntcore/tests/test_entry.py
+++ b/subprojects/pyntcore/tests/test_entry.py
@@ -3,6 +3,25 @@
 #
 
 
+def test_entry_repr(nt):
+    e = nt.getEntry("/k1")
+    assert repr(e) == "<NetworkTableEntry /k1>"
+
+
+def test_topic_repr(nt):
+    topic = nt.getIntegerTopic("/int")
+    assert repr(topic) == "<IntegerTopic /int>"
+
+    pub = topic.publish()
+    assert repr(pub) == "<IntegerPublisher /int>"
+
+    entry = topic.getEntry(0)
+    assert repr(entry) == "<IntegerEntry /int>"
+
+    generic_entry = topic.getGenericEntry()
+    assert repr(generic_entry) == "<GenericEntry /int>"
+
+
 def test_entry_string(nt):
     e = nt.getEntry("/k1")
     assert e.getString(None) is None

--- a/subprojects/pyntcore/tests/test_entry.py
+++ b/subprojects/pyntcore/tests/test_entry.py
@@ -5,21 +5,21 @@
 
 def test_entry_repr(nt):
     e = nt.getEntry("/k1")
-    assert repr(e) == "<NetworkTableEntry /k1>"
+    assert repr(e) == "<NetworkTableEntry '/k1'>"
 
 
 def test_topic_repr(nt):
     topic = nt.getIntegerTopic("/int")
-    assert repr(topic) == "<IntegerTopic /int>"
+    assert repr(topic) == "<IntegerTopic '/int'>"
 
     pub = topic.publish()
-    assert repr(pub) == "<IntegerPublisher /int>"
+    assert repr(pub) == "<IntegerPublisher '/int'>"
 
     entry = topic.getEntry(0)
-    assert repr(entry) == "<IntegerEntry /int>"
+    assert repr(entry) == "<IntegerEntry '/int'>"
 
     generic_entry = topic.getGenericEntry()
-    assert repr(generic_entry) == "<GenericEntry /int>"
+    assert repr(generic_entry) == "<GenericEntry '/int'>"
 
 
 def test_entry_string(nt):


### PR DESCRIPTION
Open questions:

- [x] should the repr quote the key? i.e. `<IntegerTopic '/int'>`
	- teams might include weird things in their keys, in particular keys containing `>` might make it difficult to read nested reprs
- [ ] should Topic et al's reprs include the `ntcore` module name?
	- technically it's possible to subclass the base `Topic` class (so it could be wrong), but not in a meaningful way