### PR TITLE
wpimath: Fix radians_per_second unit

### DIFF
--- a/subprojects/robotpy-wpimath/wpimath/_impl/src/type_casters/units_angular_acceleration_type_caster.h
+++ b/subprojects/robotpy-wpimath/wpimath/_impl/src/type_casters/units_angular_acceleration_type_caster.h
@@ -9,7 +9,7 @@ template <> struct handle_type_name<units::radians_per_second_squared_t> {
 };
 
 template <> struct handle_type_name<units::radians_per_second_squared> {
-  static constexpr auto name = _("wpimath.units.radians_per_second");
+  static constexpr auto name = _("wpimath.units.radians_per_second_squared");
 };
 
 template <> struct handle_type_name<units::degrees_per_second_squared_t> {

--- a/subprojects/robotpy-wpimath/wpimath/units.py
+++ b/subprojects/robotpy-wpimath/wpimath/units.py
@@ -190,7 +190,6 @@ gradians = float
 
 # angular acceleration
 radians_per_second_squared = float
-radians_per_second = float
 degrees_per_second_squared = float
 turns_per_second_squared = float
 


### PR DESCRIPTION
- Pyright freaks out over the double-alias of `radians_per_second`, showing the `Unknown` type instead wherever `radians_per_second` is used
- The `units::radians_per_second_squared` type caster's name was wrong (not that this type should ever actually show up)