### PR TITLE
Build Linux AArch64 wheels natively

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -141,6 +141,64 @@ jobs:
         name: "pypi-${{ runner.os }}-${{ matrix.python_version }}"
         path: dist
 
+  build-arm:
+    runs-on: ubuntu-24.04-arm
+    needs: [setup_concurrency]
+    strategy:
+      max-parallel: ${{ fromJSON(needs.setup_concurrency.outputs.max-parallel).v }}
+      fail-fast: true
+      matrix:
+        python_version:
+        - '3.11'
+        - '3.12'
+        - '3.13'
+    container: python:${{ matrix.python_version }}-bookworm
+
+    steps:
+    - run: apt-get update && apt-get install -y libgl1
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    #
+    # Setup build caching
+    #
+
+    - name: Setup sccache
+      uses: mozilla-actions/sccache-action@v0.0.7
+
+    # See https://github.com/pypa/setuptools_scm/issues/784
+    - name: Set git directory as safe to allow setuptools-scm to work
+      shell: bash
+      run: |
+        /usr/bin/git config --global --add safe.directory $PWD
+
+    - name: Install deps
+      shell: bash
+      run: |
+        python -m pip --disable-pip-version-check install -r rdev_requirements.txt
+
+    - name: Install numpy (needed for stubgen)
+      shell: bash
+      run: |
+        python -m pip --disable-pip-version-check install numpy
+
+    - name: Build + test wheels
+      shell: bash
+      run: |
+        ./rdev.sh ci run
+      env:
+        RPYBUILD_STRIP_LIBPYTHON: "1"
+        RPYBUILD_CC_LAUNCHER: sccache
+        SCCACHE_WEBDAV_USERNAME: ${{ secrets.WPI_ARTIFACTORY_USERNAME }}
+        SCCACHE_WEBDAV_PASSWORD: ${{ secrets.WPI_ARTIFACTORY_TOKEN }}
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: "pypi-${{ runner.os }}-arm-${{ matrix.python_version }}"
+        path: dist
+
   #
   # Build roboRIO/raspbian wheels
   #
@@ -161,13 +219,6 @@ jobs:
           name: raspbian-py312
         - container: wpilib/raspbian-cross-ubuntu:2025-bookworm-22.04-py313
           name: raspbian-py313
-
-        - container: wpilib/aarch64-cross-ubuntu:2025-bookworm-22.04-py311
-          name: raspbian-aarch64-py311
-        - container: wpilib/aarch64-cross-ubuntu:2025-bookworm-22.04-py312
-          name: raspbian-aarch64-py312
-        - container: wpilib/aarch64-cross-ubuntu:2025-bookworm-22.04-py313
-          name: raspbian-aarch64-py313
 
     container:
       image: "${{ matrix.os.container }}"
@@ -228,7 +279,7 @@ jobs:
 
   publish-rpyrepo:
     runs-on: ubuntu-latest
-    needs: [check, build, cross-build]
+    needs: [check, build, build-arm, cross-build]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
     steps:
@@ -248,7 +299,7 @@ jobs:
 
   publish-pypi:
     runs-on: ubuntu-latest
-    needs: [check, build, cross-build]
+    needs: [check, build, build-arm, cross-build]
     permissions:
       id-token: write
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -95,12 +95,17 @@ jobs:
     - name: Set ccache params
       shell: bash
       id: ccache
+      env:
+        OS: ${{ runner.os }}
       run: |
-        if [[ "${{ runner.os }}" != "Linux" ]]; then
+        if [[ "$OS" != "Linux" ]]; then
           echo "VARIANT=sccache" >> $GITHUB_OUTPUT
         else
           echo "VARIANT=ccache" >> $GITHUB_OUTPUT
           echo "MAX_SIZE=500M" >> $GITHUB_OUTPUT
+        fi
+        if [[ "$OS" == "macOS" ]]; then
+          echo "SCCACHE_CACHE_MULTIARCH=1" >> $GITHUB_ENV
         fi
 
     - name: Setup ccache
@@ -132,7 +137,6 @@ jobs:
       env:
         RPYBUILD_STRIP_LIBPYTHON: "1"
         RPYBUILD_CC_LAUNCHER: ${{ steps.ccache.outputs.variant }}
-        SCCACHE_CACHE_MULTIARCH: "1"
         SCCACHE_WEBDAV_USERNAME: ${{ secrets.WPI_ARTIFACTORY_USERNAME }}
         SCCACHE_WEBDAV_PASSWORD: ${{ secrets.WPI_ARTIFACTORY_TOKEN }}
 

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -146,7 +146,7 @@ jobs:
         path: dist
 
   build-arm:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     needs: [setup_concurrency]
     strategy:
       max-parallel: ${{ fromJSON(needs.setup_concurrency.outputs.max-parallel).v }}

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -15,7 +15,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  SCCACHE_CACHE_MULTIARCH: "1"
   SCCACHE_WEBDAV_ENDPOINT: "https://frcmaven.wpi.edu/artifactory/wpilib-generic-cache-cmake-local"
   SCCACHE_WEBDAV_KEY_PREFIX: "sccache-robotpy"
 
@@ -133,6 +132,7 @@ jobs:
       env:
         RPYBUILD_STRIP_LIBPYTHON: "1"
         RPYBUILD_CC_LAUNCHER: ${{ steps.ccache.outputs.variant }}
+        SCCACHE_CACHE_MULTIARCH: "1"
         SCCACHE_WEBDAV_USERNAME: ${{ secrets.WPI_ARTIFACTORY_USERNAME }}
         SCCACHE_WEBDAV_PASSWORD: ${{ secrets.WPI_ARTIFACTORY_TOKEN }}
 

--- a/devtools/subproject.py
+++ b/devtools/subproject.py
@@ -128,7 +128,9 @@ class Subproject:
 
     _adjust_wheel_tags = {
         # pypi only accepts manylinux wheels, and we know we're compatible
+        # TODO(davo): use auditwheel to fix the tags instead
         "linux_x86_64": "manylinux_2_35_x86_64",
+        "linux_aarch64": "manylinux_2_36_aarch64",
         # needed for compatibility with python compiled with older xcode
         "macosx_11_0_x86_64": "macosx_10_16_x86_64",
         "macosx_12_0_x86_64": "macosx_10_16_x86_64",


### PR DESCRIPTION
This adds jobs to build wheels on Debian Bookworm native ARM64, with the intent of publishing these wheels to PyPI.

Closes #81