### PR TITLE
ci: Use sccache for Linux amd64 builds

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -98,26 +98,11 @@ jobs:
       env:
         OS: ${{ runner.os }}
       run: |
-        if [[ "$OS" != "Linux" ]]; then
-          echo "VARIANT=sccache" >> $GITHUB_OUTPUT
-        else
-          echo "VARIANT=ccache" >> $GITHUB_OUTPUT
-          echo "MAX_SIZE=500M" >> $GITHUB_OUTPUT
-        fi
         if [[ "$OS" == "macOS" ]]; then
           echo "SCCACHE_CACHE_MULTIARCH=1" >> $GITHUB_ENV
         fi
 
-    - name: Setup ccache
-      if: steps.ccache.outputs.variant == 'ccache'
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-          key: ${{ matrix.os }}-${{ matrix.python_version }}
-          variant: ccache
-          max-size: ${{ steps.ccache.outputs.max_size }}
-
     - name: Setup sccache
-      if: steps.ccache.outputs.variant == 'sccache'
       uses: mozilla-actions/sccache-action@v0.0.7
 
     - name: Install deps
@@ -136,7 +121,7 @@ jobs:
         ./rdev.sh ci run
       env:
         RPYBUILD_STRIP_LIBPYTHON: "1"
-        RPYBUILD_CC_LAUNCHER: ${{ steps.ccache.outputs.variant }}
+        RPYBUILD_CC_LAUNCHER: sccache
         SCCACHE_WEBDAV_USERNAME: ${{ secrets.WPI_ARTIFACTORY_USERNAME }}
         SCCACHE_WEBDAV_PASSWORD: ${{ secrets.WPI_ARTIFACTORY_TOKEN }}
 


### PR DESCRIPTION
This will let us share caches with the allwpilib tools build, and keep our caches around for longer than a week.

[RobotPy artifactory cache](https://frcmaven.wpi.edu/ui/repos/tree/General/wpilib-generic-cache-cmake-local/sccache-robotpy) size before:
> Artifact Count / Size:	8202 / 9.12 GB