### PR TITLE
Fix HAL dependencies

### DIFF
--- a/subprojects/robotpy-hal/pyproject.toml
+++ b/subprojects/robotpy-hal/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "semiwrap~=0.1.4",
     "hatch-meson~=0.1.0b2",
     "hatchling",
+    "pyntcore==2027.0.0a2",
     "robotpy-native-wpihal==2027.0.0a2",
     "robotpy-wpiutil==2027.0.0a2",
 ]
@@ -17,6 +18,7 @@ authors = [
 ]
 license = "BSD-3-Clause"
 dependencies = [
+    "pyntcore==2027.0.0a2",
     "robotpy-native-wpihal==2027.0.0a2",
     "robotpy-wpiutil==2027.0.0a2",
 ]


### PR DESCRIPTION
Found during my bazel bringup. This line `depends = ["wpiutil", "ntcore"]` was happening with no explicit dependency on `pyntcore`. The build script builds them in an order such that ntcore gets built and installed first so it gets missed. Also unlikely that someone would _just_ do a `pip install pip install robotpy-hal==2027.0.0a2` instead of all of wpilib, but if you do, you get this

```
(.venv) pjreiniger@BOOK-86GHH7D7KK: pip install robotpy-hal==2027.0.0a2


(.venv) pjreiniger@BOOK-86GHH7D7KK:~/git/robotpy$ python
Python 3.12.3 (main, Jun 18 2025, 17:59:45) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import hal
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/pjreiniger/git/robotpy/.venv/lib/python3.12/site-packages/hal/__init__.py", line 4, in <module>
    from . import _initialize
  File "/home/pjreiniger/git/robotpy/.venv/lib/python3.12/site-packages/hal/_initialize.py", line 1, in <module>
    from . import exceptions, _init__wpiHal, _wpiHal
  File "/home/pjreiniger/git/robotpy/.venv/lib/python3.12/site-packages/hal/_init__wpiHal.py", line 6, in <module>
    import ntcore._init__ntcore
ModuleNotFoundError: No module named 'ntcore'
```