### PR TITLE
wpimath: Remove floorDiv and floorMod

### DIFF
--- a/subprojects/robotpy-wpimath/semiwrap/MathUtil.yml
+++ b/subprojects/robotpy-wpimath/semiwrap/MathUtil.yml
@@ -4,21 +4,13 @@ functions:
     - [double]
   AngleModulus:
   FloorDiv:
-    template_impls:
-    - [int64_t, int64_t]
-    # work around GCC 10 issue on raspbian
-    cpp_code: |
-      [](int64_t x, int64_t y) -> int64_t {
-        return frc::FloorDiv(x, y);
-      }
+    # Use // operator instead, it's more efficient
+    # - https://github.com/robotpy/mostrobotpy/pull/200
+    ignore: true
   FloorMod:
-    template_impls:
-    - [int64_t, int64_t]
-    # work around GCC 10 issue on raspbian
-    cpp_code: |
-      [](int64_t x, int64_t y) -> int64_t {
-        return frc::FloorMod(x, y);
-      }
+    # Use % operator instead, it's more efficient
+    # - https://github.com/robotpy/mostrobotpy/pull/200
+    ignore: true
   ApplyDeadband:
     param_override:
       maxMagnitude:

--- a/subprojects/robotpy-wpimath/wpimath/__init__.py
+++ b/subprojects/robotpy-wpimath/wpimath/__init__.py
@@ -7,8 +7,6 @@ from . import geometry
 from ._wpimath import (
     angleModulus,
     applyDeadband,
-    floorDiv,
-    floorMod,
     inputModulus,
     objectToRobotPose,
     slewRateLimit,
@@ -17,8 +15,6 @@ from ._wpimath import (
 __all__ = [
     "angleModulus",
     "applyDeadband",
-    "floorDiv",
-    "floorMod",
     "inputModulus",
     "objectToRobotPose",
     "slewRateLimit",


### PR DESCRIPTION
These functions provide identical results to the native Python operators `//` and `%`. I've verified this is true by property testing with [hypothesis](https://hypothesis.readthedocs.io).

```python
from hypothesis import assume, given, strategies as st

int64 = st.integers(-2**63, 2**63 - 1)


@given(int64, int64)
def test_floorDiv(a, b):
    assume(b != 0)
    from wpimath import floorDiv

    output = floorDiv(a, b)
    assert output == a // b


@given(int64, int64)
def test_floorMod(a, b):
    assume(b != 0)
    from wpimath import floorMod

    output = floorMod(a, b)
    assert output == a % b
```

These functions are objectively worse than the native operators in two ways:

- They only accept integers that fit in a 64-bit int.
- They have worse performance (presumably due to binding overhead). I've benchmarked these functions on my laptop* against the functions in the [`operator`](https://docs.python.org/3/library/operator.html) module, and the native operators consistently win out from a random sample -- [pytest-codspeed](https://codspeed.io/docs/benchmarks/python) consistently runs almost 2x iterations of the native operators with less total runtime.

\* Framework Laptop 13, AMD Ryzen 5 7640U, Fedora Linux 42, Python 3.12.11, kernel 6.16.7-200.fc42.x86_64