### PR TITLE
Fixes rtd yml to correct artifact

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,8 +9,7 @@ build:
     python: "3.11"
   jobs:
     post_install:
-    - python -m robotpy_sphinx.download_and_install robotpy mostrobotpy main dist pypi-other-X64-3.11
-    - python -m robotpy_sphinx.download_and_install robotpy mostrobotpy main dist pypi-Linux-X64-3.11
+    - python -m robotpy_sphinx.download_and_install robotpy mostrobotpy main dist pypi-meson-Linux-X64-3.11
     post_build:
     - mkdir --parents _readthedocs/htmlzip
     - cp --recursive _readthedocs/html _readthedocs/$READTHEDOCS_PROJECT


### PR DESCRIPTION
Adds the correct artifact name as both pypi-other-X64-3.11 and pypi-Linux-X64-3.11 does not exist in the artifact list