### PR TITLE
Add builtin robot tests that exercise all opmodes

### DIFF
--- a/subprojects/robotpy-wpilib/tests/test_pytest_plugins.py
+++ b/subprojects/robotpy-wpilib/tests/test_pytest_plugins.py
@@ -7,6 +7,7 @@ import pytest
 def _make_robot_module(pytester):
     pytester.makepyfile(robot_module="""
 import wpilib
+from hal import RobotMode
 
 
 class DummyRobot(wpilib.TimedRobot):
@@ -50,6 +51,42 @@ class IterativeStateRobot(wpilib.TimedRobot):
     def teleopPeriodic(self):
         self.did_teleop_periodic = True
 
+
+class OpModeAuto(wpilib.OpMode):
+    label = "OpModeAuto"
+
+    def __init__(self, robot):
+        super().__init__()
+        self._robot = robot
+
+    def opModeRun(self, op_mode_id: int):
+        self._robot.opmode_test_observed.add(self.label)
+
+    def opModeStop(self):
+        pass
+
+
+class OpModeTeleop(wpilib.OpMode):
+    label = "OpModeTeleop"
+
+    def __init__(self, robot):
+        super().__init__()
+        self._robot = robot
+
+    def opModeRun(self, op_mode_id: int):
+        self._robot.opmode_test_observed.add(self.label)
+
+    def opModeStop(self):
+        pass
+
+
+class OpModeDemoRobot(wpilib.OpModeRobot):
+    def __init__(self):
+        super().__init__()
+        self.opmode_test_observed = set()
+        self.addOpMode(OpModeAuto, RobotMode.AUTONOMOUS, "OpModeAuto")
+        self.addOpMode(OpModeTeleop, RobotMode.TELEOPERATED, "OpModeTeleop")
+        self.publishOpModes()
 """)
 
 
@@ -275,7 +312,42 @@ def test_builtin_tests_module(pytester, isolated):
 
     result = pytester.runpytest_subprocess("-q")
 
-    result.assert_outcomes(passed=4)
+    result.assert_outcomes(passed=4, skipped=1)
+
+
+@pytest.mark.parametrize("isolated", [False, True])
+def test_builtin_tests_module_opmode(pytester, isolated):
+    _make_robot_module(pytester)
+    if isolated:
+        _configure_isolated_plugin(pytester, robot_class="OpModeDemoRobot")
+    else:
+        _configure_robot_testing_plugin(pytester, robot_class="OpModeDemoRobot")
+    pytester.makepyfile(pyfrc_test="from wpilib.testing.robot_tests import *\n")
+
+    result = pytester.runpytest_subprocess("-q")
+
+    result.assert_outcomes(passed=5)
+
+
+@pytest.mark.parametrize("isolated", [False, True])
+def test_opmode_robot_runs_opmodes(pytester, isolated):
+    _make_robot_module(pytester)
+    if isolated:
+        _configure_isolated_plugin(pytester, robot_class="OpModeDemoRobot")
+    else:
+        _configure_robot_testing_plugin(pytester, robot_class="OpModeDemoRobot")
+    pytester.makepyfile(test_robot="""
+from wpilib.testing.robot_tests import test_all_opmodes
+
+
+def test_opmodes_run(robot, control):
+    test_all_opmodes(control)
+    assert robot.opmode_test_observed == {"OpModeAuto", "OpModeTeleop"}
+""")
+
+    result = pytester.runpytest_subprocess("-q")
+
+    result.assert_outcomes(passed=2)
 
 
 def _run_robot_suite(pytester, isolated, robot_class, test_source, *args):

--- a/subprojects/robotpy-wpilib/wpilib/testing/pytest_plugin.py
+++ b/subprojects/robotpy-wpilib/wpilib/testing/pytest_plugin.py
@@ -76,7 +76,9 @@ class RobotTestingPlugin:
         wpilib.DriverStation.silenceJoystickConnectionWarning(True)
         DriverStationSim.setRobotMode(RobotMode.AUTONOMOUS)
         DriverStationSim.setEnabled(False)
+        DriverStationSim.setOpMode(0)
         DriverStationSim.notifyNewData()
+        wpilib.DriverStation.clearOpModes()
 
         # Create the user's robot instance
         robot = self._robot_class()


### PR DESCRIPTION
- Fixes #220

I'm not really sure what testing all opmodes really means; should it just briefly run it, or run it for a full autonomous/teleop period similar to the 'test_practice' test?

Here's what I have at the moment (courtesy of Codex), and it seems to work, but it feels like it doesn't really test what it should.