### PR TITLE
Fix Translation3d cross numpy conversion

### DIFF
--- a/subprojects/robotpy-wpimath/semiwrap/Translation3d.yml
+++ b/subprojects/robotpy-wpimath/semiwrap/Translation3d.yml
@@ -2,6 +2,7 @@ extra_includes:
 - geometryToString.h
 - wpystruct.h
 - pybind11/eigen.h
+- units_numpy_type_caster.h
 
 functions:
   to_json:

--- a/subprojects/robotpy-wpimath/wpimath/_impl/src/type_casters/units_numpy_type_caster.h
+++ b/subprojects/robotpy-wpimath/wpimath/_impl/src/type_casters/units_numpy_type_caster.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <pybind11/numpy.h>
+
+namespace pybind11 {
+namespace detail {
+
+template <class U, typename T, template <typename> class S>
+struct npy_format_descriptor<wpi::units::unit_t<U, T, S>> {
+  static constexpr auto name = const_name("numpy.float64");
+  static constexpr int value = npy_api::NPY_DOUBLE_;
+
+  static pybind11::dtype dtype() { return pybind11::dtype(value); }
+};
+
+} // namespace detail
+} // namespace pybind11


### PR DESCRIPTION
@pjreiniger this fixes the problem you ran into

Adding the npy_format_descriptor to the base unit type caster increased compilation time a ton, so I'm not going to do that there.