### PR TITLE
[wpilibc] Fix LED crash related to the GIL

### DIFF
--- a/subprojects/robotpy-wpilib/semiwrap/AddressableLED.yml
+++ b/subprojects/robotpy-wpilib/semiwrap/AddressableLED.yml
@@ -22,6 +22,10 @@ classes:
       SetGlobalData:
     enums:
       ColorOrder:
+    inline_code: |
+      .def("setData", [](wpi::AddressableLED& self, const wpi::AddressableLEDBuffer& data) {
+            return self.SetData(data); 
+          }, py::prepend());
   wpi::AddressableLED::LEDData:
     force_no_trampoline: true
     ignored_bases:

--- a/subprojects/robotpy-wpilib/semiwrap/AddressableLED.yml
+++ b/subprojects/robotpy-wpilib/semiwrap/AddressableLED.yml
@@ -14,10 +14,6 @@ classes:
         overloads:
           std::span<const LEDData>:
           std::initializer_list<LEDData>:
-            cpp_code: |
-              [](wpi::AddressableLED& self, const wpi::AddressableLEDBuffer& data) {
-                return self.SetData(data);
-              }, py::prepend()
             ignore: true
       SetColorOrder:
       GetChannel:

--- a/subprojects/robotpy-wpilib/semiwrap/AddressableLED.yml
+++ b/subprojects/robotpy-wpilib/semiwrap/AddressableLED.yml
@@ -25,7 +25,7 @@ classes:
     inline_code: |
       .def("setData", [](wpi::AddressableLED& self, const wpi::AddressableLEDBuffer& data) {
             return self.SetData(data); 
-          }, py::prepend());
+          }, release_gil(), py::prepend());
   wpi::AddressableLED::LEDData:
     force_no_trampoline: true
     ignored_bases:

--- a/subprojects/robotpy-wpilib/semiwrap/AddressableLED.yml
+++ b/subprojects/robotpy-wpilib/semiwrap/AddressableLED.yml
@@ -18,6 +18,7 @@ classes:
               [](wpi::AddressableLED& self, const wpi::AddressableLEDBuffer& data) {
                 return self.SetData(data);
               }, py::prepend()
+            ignore: true
       SetColorOrder:
       GetChannel:
       SetStart:

--- a/subprojects/robotpy-wpilib/semiwrap/AddressableLEDBuffer.yml
+++ b/subprojects/robotpy-wpilib/semiwrap/AddressableLEDBuffer.yml
@@ -23,6 +23,7 @@ classes:
         ignore: true
       CreateView:
         rename: __getitem__
+        no_release_gil: true
         keepalive:
         - [0, 1]
     inline_code: |


### PR DESCRIPTION
When building in debug mode, a GIL error was detected because it was not being released correctly. This fixes it both in here and in `allwpilib` land