### PR TITLE
fix(ntcore): register bool put/set overloads before double

### DIFF
--- a/subprojects/pyntcore/ntcore/src/NetworkTable.cpp.inl
+++ b/subprojects/pyntcore/ntcore/src/NetworkTable.cpp.inl
@@ -14,12 +14,13 @@ cls_NetworkTable
         return pyntcore::GetValueEntry(entry, defaultValue);
     }, py::arg("key"), py::arg("value"))
 
-    // double overload must come before boolean version
-    .def("put_value", [](wpi::nt::NetworkTable *self, std::string_view key, double value) {
-        return self->PutValue(key, wpi::nt::Value::MakeDouble(value));
-    }, py::arg("key"), py::arg("value"), release_gil())
+    // bool before double: under pybind11 3.1, bool subclasses int and would
+    // otherwise bind the double overload (see robotpy/mostrobotpy#318).
     .def("put_value", [](wpi::nt::NetworkTable *self, std::string_view key, bool value) {
         return self->PutValue(key, wpi::nt::Value::MakeBoolean(value));
+    }, py::arg("key"), py::arg("value").noconvert(), release_gil())
+    .def("put_value", [](wpi::nt::NetworkTable *self, std::string_view key, double value) {
+        return self->PutValue(key, wpi::nt::Value::MakeDouble(value));
     }, py::arg("key"), py::arg("value"), release_gil())
     .def("put_value", [](wpi::nt::NetworkTable *self, std::string_view key, py::bytes value) {
         auto v = wpi::nt::Value::MakeRaw(value.cast<std::span<const uint8_t>>());
@@ -35,12 +36,13 @@ cls_NetworkTable
         return self->PutValue(key, v);
     }, py::arg("key"), py::arg("value"))
 
-    // double overload must come before boolean version
-    .def("set_default_value", [](wpi::nt::NetworkTable *self, std::string_view key, double value) {
-        return self->SetDefaultValue(key, wpi::nt::Value::MakeDouble(value));
-    }, py::arg("key"), py::arg("value"), release_gil())
+    // bool before double: under pybind11 3.1, bool subclasses int and would
+    // otherwise bind the double overload (see robotpy/mostrobotpy#318).
     .def("set_default_value", [](wpi::nt::NetworkTable *self, std::string_view key, bool value) {
         return self->SetDefaultValue(key, wpi::nt::Value::MakeBoolean(value));
+    }, py::arg("key"), py::arg("value").noconvert(), release_gil())
+    .def("set_default_value", [](wpi::nt::NetworkTable *self, std::string_view key, double value) {
+        return self->SetDefaultValue(key, wpi::nt::Value::MakeDouble(value));
     }, py::arg("key"), py::arg("value"), release_gil())
     .def("set_default_value", [](wpi::nt::NetworkTable *self, std::string_view key, py::bytes value) {
         auto v = wpi::nt::Value::MakeRaw(value.cast<std::span<const uint8_t>>());

--- a/subprojects/pyntcore/ntcore/src/NetworkTableEntry.cpp.inl
+++ b/subprojects/pyntcore/ntcore/src/NetworkTableEntry.cpp.inl
@@ -13,12 +13,13 @@ cls_NetworkTableEntry
         return pyntcore::ntvalue2py(v);
     })
 
-    // double overload must come before boolean version
-    .def("set_value", [](wpi::nt::NetworkTableEntry *self, double value) {
-        return self->SetValue(wpi::nt::Value::MakeDouble(value));
-    }, py::arg("value"), release_gil())
+    // bool before double: under pybind11 3.1, bool subclasses int and would
+    // otherwise bind the double overload (see robotpy/mostrobotpy#318).
     .def("set_value", [](wpi::nt::NetworkTableEntry *self, bool value) {
         return self->SetValue(wpi::nt::Value::MakeBoolean(value));
+    }, py::arg("value").noconvert(), release_gil())
+    .def("set_value", [](wpi::nt::NetworkTableEntry *self, double value) {
+        return self->SetValue(wpi::nt::Value::MakeDouble(value));
     }, py::arg("value"), release_gil())
     .def("set_value", [](wpi::nt::NetworkTableEntry *self, py::bytes value) {
         auto v = wpi::nt::Value::MakeRaw(value.cast<std::span<const uint8_t>>());
@@ -32,12 +33,13 @@ cls_NetworkTableEntry
         return self->SetValue(pyntcore::py2ntvalue(value));
     }, py::arg("value"))
 
-    // double overload must come before boolean version
-    .def("set_default_value", [](wpi::nt::NetworkTableEntry *self, double value) {
-        return self->SetDefaultValue(wpi::nt::Value::MakeDouble(value));
-    }, py::arg("value"), release_gil())
+    // bool before double: under pybind11 3.1, bool subclasses int and would
+    // otherwise bind the double overload (see robotpy/mostrobotpy#318).
     .def("set_default_value", [](wpi::nt::NetworkTableEntry *self, bool value) {
         return self->SetDefaultValue(wpi::nt::Value::MakeBoolean(value));
+    }, py::arg("value").noconvert(), release_gil())
+    .def("set_default_value", [](wpi::nt::NetworkTableEntry *self, double value) {
+        return self->SetDefaultValue(wpi::nt::Value::MakeDouble(value));
     }, py::arg("value"), release_gil())
     .def("set_default_value", [](wpi::nt::NetworkTableEntry *self, py::bytes value) {
         auto v = wpi::nt::Value::MakeRaw(value.cast<std::span<const uint8_t>>());


### PR DESCRIPTION
## Summary
- Under pybind11 3.1, Python `bool` can bind the earlier `double` overload because `bool` subclasses `int`.
- Register the `bool` overload first, with `.noconvert()` on the value, for:
  - `NetworkTable.put_value` / `set_default_value`
  - `NetworkTableEntry.set_value` / `set_default_value`
- Existing `test_getvalue_overloads` covers `put_value("boolean", True)`.

Closes #318

## Test plan
- [ ] CI: pyntcore / ntcore tests including `tests/test_network_table.py::test_getvalue_overloads`
- [ ] Confirm `put_value(..., True)` stores a boolean, while numeric `1` / `1.0` still store doubles